### PR TITLE
Fix signup to redirect to login instead of auto-login

### DIFF
--- a/mobile/app/screens/auth/LoginScreen.js
+++ b/mobile/app/screens/auth/LoginScreen.js
@@ -54,7 +54,9 @@ const LoginScreen = ({ showSignup = false }) => {
     setLoading(true);
     try {
       await signup(email, password, fullName, phoneNumber);
-      // Auth state will change and home screen will auto-update
+      Alert.alert('Success', 'Account created successfully. Please login.');
+      setIsSignup(false);
+      setPassword('');
     } catch (err) {
       const errorMessage = err.response?.data?.error || err.message || 'Something went wrong';
       console.log('Signup error:', err);

--- a/mobile/contexts/AuthContext.js
+++ b/mobile/contexts/AuthContext.js
@@ -32,11 +32,6 @@ export const AuthProvider = ({ children }) => {
   const signup = async (email, password, fullName, phoneNumber) => {
     try {
       const response = await authAPI.signup(email, password, fullName, phoneNumber);
-      if (response.data.token) {
-        await AsyncStorage.setItem('token', response.data.token);
-        setToken(response.data.token);
-        setUser(response.data.user);
-      }
       return response.data;
     } catch (err) {
       console.error('Signup error in context:', err);


### PR DESCRIPTION
## Summary
- Removed auto-login after signup in `AuthContext.js` (no longer stores token/user state)
- After successful signup, shows a success alert and switches to the login form
- Password field is cleared for security; email stays pre-filled for convenience

Closes #10

## Test plan
- [x] Sign up with a new account and verify you see the success alert
- [x] Confirm the view switches to the login form (not auto-logged in)
- [x] Verify the email is pre-filled and password is cleared
- [x] Log in with the new credentials and confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)