### PR TITLE
Show sport type and weekday in session details modal

### DIFF
--- a/mobile/app/components/sessions/SessionDetailsModal.js
+++ b/mobile/app/components/sessions/SessionDetailsModal.js
@@ -296,6 +296,11 @@ const SessionDetailsModal = ({
                 <Text style={styles.infoCardValue}>
                   {session?.scheduled_date ? formatDateTime(session.scheduled_date) : ''}
                 </Text>
+                {session?.scheduled_date && (
+                  <Text style={styles.infoCardSubtext}>
+                    {new Date(session.scheduled_date).toLocaleDateString('en-US', { weekday: 'long' })}
+                  </Text>
+                )}
               </View>
 
               <View style={styles.infoCard}>
@@ -319,6 +324,11 @@ const SessionDetailsModal = ({
               <View style={styles.infoCard}>
                 <Text style={styles.infoCardLabel}>💰 Total Cost</Text>
                 <Text style={styles.infoCardValue}>₹{session?.total_cost}</Text>
+              </View>
+
+              <View style={styles.infoCard}>
+                <Text style={styles.infoCardLabel}>🏅 Sport</Text>
+                <Text style={styles.infoCardValue}>{session?.sport_type || '-'}</Text>
               </View>
 
               <View style={[styles.infoCard, styles.infoCardFullWidth]}>

--- a/mobile/app/components/sessions/SessionDetailsModal.styles.js
+++ b/mobile/app/components/sessions/SessionDetailsModal.styles.js
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
   },
   infoCard: {
     flex: 1,
-    minWidth: '45%',
+    minWidth: '44%',
     backgroundColor: '#f8f9fa',
     padding: 12,
     borderRadius: 12,
@@ -68,6 +68,11 @@ const styles = StyleSheet.create({
     fontSize: 15,
     color: '#333',
     fontWeight: '600',
+  },
+  infoCardSubtext: {
+    fontSize: 16,
+    color: '#666',
+    marginTop: 2,
   },
   participantsSection: {
     marginBottom: 20,


### PR DESCRIPTION
## Summary
- Added a Sport card (showing `sport_type`) to the right of Total Cost in the info grid
- Added the weekday (e.g. "Sunday") below the date on the Date card
- Adjusted `infoCard` `minWidth` from 45% to 44% so cards fit side-by-side with the gap

Closes #11

## Test plan
- [x] Open a session modal and verify Sport appears next to Total Cost
- [x] Verify the Date card shows the weekday below the date
- [x] Check layout on different screen sizes to ensure cards stay side-by-side
