### PR TITLE
Auto-complete sessions and add Done tab (Issue #18)

### DIFF
--- a/mobile/app/components/sessions/SessionDetailsModal.js
+++ b/mobile/app/components/sessions/SessionDetailsModal.js
@@ -167,6 +167,7 @@ const SessionDetailsModal = ({
 
   const renderActionButton = () => {
     if (!session) return null;
+    if (session.status === 'completed') return null;
 
     // ── MySessionsScreen mode ──────────────────────────────────────────────
     if (activeTab !== null && activeTab !== undefined) {
@@ -390,10 +391,12 @@ const SessionDetailsModal = ({
             {renderActionButton()}
 
             {/* Invite / share button */}
-            <TouchableOpacity style={styles.inviteButton} onPress={handleShareSession}>
-              <Text style={styles.inviteButtonIcon}>🔗</Text>
-              <Text style={styles.inviteButtonText}>Invite Friends</Text>
-            </TouchableOpacity>
+            {session?.status !== 'completed' && (
+              <TouchableOpacity style={styles.inviteButton} onPress={handleShareSession}>
+                <Text style={styles.inviteButtonIcon}>🔗</Text>
+                <Text style={styles.inviteButtonText}>Invite Friends</Text>
+              </TouchableOpacity>
+            )}
           </ScrollView>
         </View>
       </View>

--- a/mobile/app/screens/sessions/MySessionsScreen.styles.js
+++ b/mobile/app/screens/sessions/MySessionsScreen.styles.js
@@ -88,6 +88,10 @@ const styles = StyleSheet.create({
     shadowRadius: 3,
     elevation: 3,
   },
+  sessionCardFull: {
+    borderBottomLeftRadius: 12,
+    borderBottomRightRadius: 12,
+  },
   buttonContainer: {
     flexDirection: 'row',
     gap: 8,
@@ -148,6 +152,10 @@ const styles = StyleSheet.create({
   fullStatus: {
     backgroundColor: '#ffcccc',
     color: '#c62828',
+  },
+  completedStatus: {
+    backgroundColor: '#e0e0e0',
+    color: '#555',
   },
   location: {
     fontSize: 13,

--- a/mobile/app/screens/sessions/SessionsListScreen.styles.js
+++ b/mobile/app/screens/sessions/SessionsListScreen.styles.js
@@ -330,6 +330,10 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffcccc',
     color: '#c62828',
   },
+  completedStatus: {
+    backgroundColor: '#e0e0e0',
+    color: '#555',
+  },
   location: {
     fontSize: 13,
     color: '#666',


### PR DESCRIPTION
## Summary
- Backend: Sessions are automatically marked as `completed` when their end time passes (IST timezone)
- Frontend: Moved "Done" tab from Sessions screen to My Sessions screen (Joined | Created | Done)
- Completed sessions hide all action buttons (Leave, Cancel, Join, Invite Friends) in both card view and details modal
- Both screens auto-refresh every 5 minutes to pick up newly completed sessions

Closes #18

## Test plan
- [x] Create a session with a past end time → it appears under Done tab in My Sessions
- [x] Open/Full tabs on Sessions screen no longer show expired sessions
- [x] Session details modal hides Leave and Invite Friends for completed sessions
- [x] Active sessions remain unaffected
- [x] Auto-refresh picks up status changes without manual pull-to-refresh
