### PR TITLE
Add Android deep linking for shared session URLs

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -33,6 +33,18 @@
             }
           ],
           "category": ["BROWSABLE", "DEFAULT"]
+        },
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "data": [
+            {
+              "scheme": "https",
+              "host": "lineup-sports.vercel.app",
+              "pathPrefix": "/sessions/"
+            }
+          ],
+          "category": ["BROWSABLE", "DEFAULT"]
         }
       ]
     },
@@ -61,7 +73,9 @@
       "reactCompiler": true
     },
     "extra": {
-      "router": {},
+      "router": {
+        "origin": "https://lineup-sports.vercel.app"
+      },
       "eas": {
         "projectId": "efd7de3b-0c1e-4726-a98f-ae5bb178ea56"
       }

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -20,6 +20,8 @@ export default function RootLayout() {
         <NavigationThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
           <Stack>
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="session/[id]" options={{ headerShown: false }} />
+            <Stack.Screen name="sessions/[id]" options={{ headerShown: false }} />
             <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
           </Stack>
           <StatusBar style="auto" />

--- a/mobile/app/session/[id].tsx
+++ b/mobile/app/session/[id].tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import { View, StyleSheet, ActivityIndicator, Text } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { AuthContext } from '../../contexts/AuthContext';
@@ -9,14 +9,9 @@ export default function SessionDeepLinkScreen() {
   const { id } = useLocalSearchParams();
   const { user, token, loading } = useContext(AuthContext);
   const router = useRouter();
-  const [sessionId, setSessionId] = useState<number | null>(null);
 
-  useEffect(() => {
-    if (id) {
-      const parsedId = typeof id === 'string' ? parseInt(id, 10) : id;
-      setSessionId(parsedId);
-    }
-  }, [id]);
+  // id can be numeric (from in-app nav) or session_id UUID (from deep link)
+  const sessionIdentifier = typeof id === 'string' ? id : String(id);
 
   if (loading) {
     return (
@@ -32,7 +27,7 @@ export default function SessionDeepLinkScreen() {
   }
 
   // Show error if no session ID
-  if (!sessionId) {
+  if (!sessionIdentifier) {
     return (
       <View style={styles.container}>
         <Text style={styles.errorText}>Invalid session link</Text>
@@ -40,10 +35,11 @@ export default function SessionDeepLinkScreen() {
     );
   }
 
-  // Show session detail screen
+  // Pass the identifier as-is — SessionDetailScreen uses sessionAPI.get()
+  // which supports both numeric id and session_id (UUID) lookup
   return (
     <SessionDetailScreen
-      route={{ params: { sessionId } }}
+      route={{ params: { sessionId: sessionIdentifier } }}
       navigation={{
         goBack: () => router.back(),
         navigate: (screen: string, params: any) => {

--- a/mobile/app/sessions/[id].tsx
+++ b/mobile/app/sessions/[id].tsx
@@ -1,0 +1,8 @@
+import { Redirect, useLocalSearchParams } from 'expo-router';
+
+// This route handles deep links from https://lineup-sports.vercel.app/sessions/{session_id}
+// It redirects to the existing session/[id] screen which handles auth and display
+export default function SessionsRedirect() {
+  const { id } = useLocalSearchParams();
+  return <Redirect href={`/session/${id}`} />;
+}

--- a/web/public/.well-known/assetlinks.json
+++ b/web/public/.well-known/assetlinks.json
@@ -1,0 +1,8 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "com.div.mysportsapp",
+    "sha256_cert_fingerprints": ["PLACEHOLDER_SHA256_FINGERPRINT"]
+  }
+}]


### PR DESCRIPTION
## Summary
- Add HTTPS intent filter in `app.json` for `lineup-sports.vercel.app/sessions/` so Android opens shared links in the app (#26)
- Host `.well-known/assetlinks.json` on Vercel for Android App Links verification (#27)
- Add `sessions/[id]` redirect route matching web URL format and update `SessionDetailScreen` to support UUID session_id from deep links (#28)

Closes #26, #27, #28

## Test plan
- [ ] Deploy web to Vercel and verify `https://lineup-sports.vercel.app/.well-known/assetlinks.json` returns valid JSON
- [ ] Rebuild APK with `eas build --platform android --profile preview`
- [ ] Install new APK on device
- [ ] Share a session link from web, tap it on Android — should open in app
- [ ] Verify session details load correctly with join/leave buttons working
- [ ] Test with logged-out user — should show login screen, then session after auth
